### PR TITLE
Cache parsed signing key for performance

### DIFF
--- a/cloudapi/local_test.go
+++ b/cloudapi/local_test.go
@@ -57,7 +57,8 @@ func (s *LocalTests) SetUpSuite(c *gc.C) {
 	s.Server.Config.Handler = s.Mux
 
 	// Set up a Joyent CloudAPI service.
-	authentication := auth.Auth{User: "localtest", PrivateKey: string(privateKey), Algorithm: "rsa-sha256"}
+	authentication, err := auth.NewAuth("localtest", string(privateKey), "rsa-sha256")
+	c.Assert(err, gc.IsNil)
 
 	s.creds = &auth.Credentials{
 		UserAuthentication: authentication,


### PR DESCRIPTION
Update to use the NewAuth constructor which caches the parsed signing key
