### PR TITLE
Serialize tags and metadata correctly

### DIFF
--- a/cloudapi/cloudapi.go
+++ b/cloudapi/cloudapi.go
@@ -480,8 +480,8 @@ type CreateMachineOpts struct {
 	Package         string            `json:"package"`          // Name of the package to use on provisioning
 	Image           string            `json:"image"`            // The image UUID
 	Networks        []string          `json:"networks"`         // Desired networks IDs
-	Metadata        map[string]string `json:"-"`                // An arbitrary set of metadata key/value pairs can be set at provision time
-	Tags            map[string]string `json:"-"`                // An arbitrary set of tags can be set at provision time
+	Metadata        map[string]string `json:"metadata"`         // An arbitrary set of metadata key/value pairs can be set at provision time
+	Tags            map[string]string `json:"tags"`             // An arbitrary set of tags can be set at provision time
 	FirewallEnabled bool              `json:"firewall_enabled"` // Completely enable or disable firewall for this machine (new in API version 7.0)
 }
 

--- a/cloudapi/cloudapi.go
+++ b/cloudapi/cloudapi.go
@@ -20,6 +20,7 @@ import (
 	"github.com/joyent/gocommon/errors"
 	jh "github.com/joyent/gocommon/http"
 	"github.com/juju/loggo"
+	"strings"
 )
 
 const (
@@ -480,8 +481,8 @@ type CreateMachineOpts struct {
 	Package         string            `json:"package"`          // Name of the package to use on provisioning
 	Image           string            `json:"image"`            // The image UUID
 	Networks        []string          `json:"networks"`         // Desired networks IDs
-	Metadata        map[string]string `json:"metadata"`         // An arbitrary set of metadata key/value pairs can be set at provision time
-	Tags            map[string]string `json:"tags"`             // An arbitrary set of tags can be set at provision time
+	Metadata        map[string]string `json:"-"`                // An arbitrary set of metadata key/value pairs can be set at provision time
+	Tags            map[string]string `json:"-"`                // An arbitrary set of tags can be set at provision time
 	FirewallEnabled bool              `json:"firewall_enabled"` // Completely enable or disable firewall for this machine (new in API version 7.0)
 }
 
@@ -535,12 +536,18 @@ func (opts CreateMachineOpts) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	for k, v := range opts.Tags {
+		if !strings.HasPrefix(k, "tag.") {
+			k = "tag." + k
+		}
 		data, err = appendJSON(data, k, v)
 		if err != nil {
 			return nil, err
 		}
 	}
 	for k, v := range opts.Metadata {
+		if !strings.HasPrefix(k, "metadata.") {
+			k = "metadata." + k
+		}
 		data, err = appendJSON(data, k, v)
 		if err != nil {
 			return nil, err

--- a/localservices/cloudapi/service.go
+++ b/localservices/cloudapi/service.go
@@ -462,7 +462,7 @@ func (c *CloudAPI) GetMachine(machineId string) (*cloudapi.Machine, error) {
 	return nil, fmt.Errorf("Machine %s not found", machineId)
 }
 
-func (c *CloudAPI) CreateMachine(name, pkg, image string, metadata, tags map[string]string) (*cloudapi.Machine, error) {
+func (c *CloudAPI) CreateMachine(name, pkg, image string, networks []string, metadata, tags map[string]string) (*cloudapi.Machine, error) {
 	if err := c.ProcessFunctionHook(c, name, pkg, image); err != nil {
 		return nil, err
 	}
@@ -482,6 +482,16 @@ func (c *CloudAPI) CreateMachine(name, pkg, image string, metadata, tags map[str
 		return nil, err
 	}
 
+	mNetworks := []string{}
+	for _, network := range networks {
+		mNetwork, err := c.GetNetwork(network)
+		if err != nil {
+			return nil, err
+		}
+
+		mNetworks = append(mNetworks, mNetwork.Id)
+	}
+
 	publicIP := generatePublicIPAddress()
 
 	newMachine := &cloudapi.Machine{
@@ -498,6 +508,7 @@ func (c *CloudAPI) CreateMachine(name, pkg, image string, metadata, tags map[str
 		Metadata:  metadata,
 		Tags:      tags,
 		PrimaryIP: publicIP,
+		Networks:  mNetworks,
 	}
 	c.machines = append(c.machines, newMachine)
 


### PR DESCRIPTION
This means that if you don't prefix your tags with `tag.` and your metadata with `metadata.`, the client will. This is a less surprising behavior.

This fixes #3.

I've also updated the test double to accept tags/metadata when sent in the proper form, and accepted the Networks field as well.