### PR TITLE
Remove unused juju/loggo Logger

### DIFF
--- a/cloudapi/cloudapi.go
+++ b/cloudapi/cloudapi.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/joyent/gocommon/client"
 	jh "github.com/joyent/gocommon/http"
-	"github.com/juju/loggo"
 )
 
 const (
@@ -57,9 +56,6 @@ const (
 	actionEnableFw  = "enable_firewall"
 	actionDisableFw = "disable_firewall"
 )
-
-// Logger for this package
-var Logger = loggo.GetLogger("gosdc.cloudapi")
 
 // Client provides a means to access the Joyent CloudAPI
 type Client struct {


### PR DESCRIPTION
This appears to be the only "fall-out" from removing `juju/loggo` from `go common`.

Edit from @misterbisson:

This was an oversight in https://github.com/joyent/gosdc/issues/11 and is part of some license cleanup triggered by https://github.com/hashicorp/terraform/pull/5277 and https://twitter.com/jen20/status/682579140466323458 before that.