### PR TITLE
Remove juju/loggo from test setup

### DIFF
--- a/cloudapi/live_test.go
+++ b/cloudapi/live_test.go
@@ -10,6 +10,8 @@
 package cloudapi_test
 
 import (
+	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -30,7 +32,7 @@ type LiveTests struct {
 }
 
 func (s *LiveTests) SetUpTest(c *gc.C) {
-	client := client.NewClient(s.creds.SdcEndpoint.URL, cloudapi.DefaultAPIVersion, s.creds, &cloudapi.Logger)
+	client := client.NewClient(s.creds.SdcEndpoint.URL, cloudapi.DefaultAPIVersion, s.creds, log.New(os.Stderr, "", log.LstdFlags))
 	c.Assert(client, gc.NotNil)
 	s.testClient = cloudapi.New(client)
 	c.Assert(s.testClient, gc.NotNil)

--- a/cloudapi/local_test.go
+++ b/cloudapi/local_test.go
@@ -8,6 +8,7 @@ package cloudapi_test
 
 import (
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -74,7 +75,7 @@ func (s *LocalTests) TearDownSuite(c *gc.C) {
 }
 
 func (s *LocalTests) SetUpTest(c *gc.C) {
-	client := client.NewClient(s.creds.SdcEndpoint.URL, cloudapi.DefaultAPIVersion, s.creds, &cloudapi.Logger)
+	client := client.NewClient(s.creds.SdcEndpoint.URL, cloudapi.DefaultAPIVersion, s.creds, log.New(os.Stderr, "", log.LstdFlags))
 	c.Assert(client, gc.NotNil)
 	s.testClient = cloudapi.New(client)
 	c.Assert(s.testClient, gc.NotNil)


### PR DESCRIPTION
This should fix the build errors seen at https://app.wercker.com/#buildstep/56eefa4b573ac62617294f17.

Edit by @misterbisson:

Should have gone with https://github.com/joyent/gosdc/pull/27. Follows from an oversight in https://github.com/joyent/gosdc/issues/11 and is part of some license cleanup triggered by https://github.com/hashicorp/terraform/pull/5277 and https://twitter.com/jen20/status/682579140466323458 before that.