### PR TITLE
Add omitempty tag to optional fields in Image

### DIFF
--- a/cloudapi/images.go
+++ b/cloudapi/images.go
@@ -44,14 +44,14 @@ type MantaLocation struct {
 // CreateImageFromMachineOpts represent the option that can be specified
 // when creating a new image from an existing machine.
 type CreateImageFromMachineOpts struct {
-	Machine     string            `json:"machine"`     // The machine UUID from which the image is to be created
-	Name        string            `json:"name"`        // Image name
-	Version     string            `json:"version"`     // Image version
-	Description string            `json:"description"` // Image description
-	Homepage    string            `json:"homepage"`    // URL for a web page including detailed information for this image
-	EULA        string            `json:"eula"`        // URL of the End User License Agreement (EULA) for the image
-	ACL         []string          `json:"acl"`         // An array of account UUIDs given access to a private image. The field is only relevant to private images
-	Tags        map[string]string `json:"tags"`        // A map of key/value pairs that allows clients to categorize images by any given criteria
+	Machine     string            `json:"machine"`               // The machine UUID from which the image is to be created
+	Name        string            `json:"name"`                  // Image name
+	Version     string            `json:"version"`               // Image version
+	Description string            `json:"description,omitempty"` // Image description
+	Homepage    string            `json:"homepage,omitempty"`    // URL for a web page including detailed information for this image
+	EULA        string            `json:"eula,omitempty"`        // URL of the End User License Agreement (EULA) for the image
+	ACL         []string          `json:"acl,omitempty"`         // An array of account UUIDs given access to a private image. The field is only relevant to private images
+	Tags        map[string]string `json:"tags,omitempty"`        // A map of key/value pairs that allows clients to categorize images by any given criteria
 }
 
 // ListImages provides a list of images available in the datacenter.


### PR DESCRIPTION
Add omitempty tag to optional fields in Image structure. Marshaling
empty fields causes image creation to fail.