### PR TITLE
Add CNS domain names metadata

### DIFF
--- a/cloudapi/machines.go
+++ b/cloudapi/machines.go
@@ -30,6 +30,7 @@ type Machine struct {
 	PrimaryIP       string            // The primary (public) IP address for the machine
 	Networks        []string          // The network IDs for the machine
 	FirewallEnabled bool              `json:"firewall_enabled"` // whether or not the firewall is enabled
+	DomainNames     []string          `json:"dns_names"` // The domain names of this machine
 }
 
 // Equals compares two machines. Ignores state and timestamps.


### PR DESCRIPTION
I would like to have the dns_names field exposed through gosdc.

The goal is to add it to include these changes in [hashicorp/terraform PR#6115](https://github.com/hashicorp/terraform/pull/6115).